### PR TITLE
Add ability to use app specific password for user accounts with 2FA

### DIFF
--- a/lib/fastlane/plugin/notarize/actions/notarize_action.rb
+++ b/lib/fastlane/plugin/notarize/actions/notarize_action.rb
@@ -31,7 +31,8 @@ module Fastlane
         apple_id_account = CredentialsManager::AccountManager.new(user: params[:username])
 
         # Add password as a temporary environment variable for altool.
-        ENV['FL_NOTARIZE_PASSWORD'] = apple_id_account.password
+        # Use app specific password if specified.
+        ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
 
         UI.message('Uploading package to notarization service, might take a while')
 


### PR DESCRIPTION
Hi.

`altool` fails to upload the app for notarization with a password specified in the Keychain, if 2FA is on.  
A workaround is to use an app-specific password.  

This PR will allow using the app-specific password from `ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD']` instead of the one stored in the Keychain.