### PR TITLE
Store log file url in environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ notarize(
 
 This action should prompt you for an Apple ID and password, using fastlane's built-in credentials manager. To use the action in a CI environment like Bitrise, CircleCI or Travis CI, you can set `FASTLANE_USER` and `FASTLANE_PASSWORD` environment variables. (Make sure to use secret environment variables, specifically for the password.)
 
+The tool also stores the `log file url` in an environment variable called `NOTARIZE_LOG_FILE_URL` for further use after the notarization. The log file contains information about errors and/or warnings that arose during notarization.
+
 ## Example
 
 Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plugin. Try it by cloning the repo, running `bundle exec fastlane test`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ notarize(
 
 This action should prompt you for an Apple ID and password, using fastlane's built-in credentials manager. To use the action in a CI environment like Bitrise, CircleCI or Travis CI, you can set `FASTLANE_USER` and `FASTLANE_PASSWORD` environment variables. (Make sure to use secret environment variables, specifically for the password.)
 
-The tool also stores the `log file url` in an environment variable called `NOTARIZE_LOG_FILE_URL` for further use after the notarization. The log file contains information about errors and/or warnings that arose during notarization.
+The tool also stores the `log file url` in an environment variable called `FL_NOTARIZE_LOG_FILE_URL` for further use after the notarization. The log file contains information about errors and/or warnings that arose during notarization.
 
 ## Example
 

--- a/lib/fastlane/plugin/notarize/actions/notarize_action.rb
+++ b/lib/fastlane/plugin/notarize/actions/notarize_action.rb
@@ -84,6 +84,7 @@ module Fastlane
         end
 
         log_url = notarization_info['LogFileURL']
+        ENV['NOTARIZE_LOG_FILE_URL'] = log_url
         log_suffix = ''
         if log_url && print_log
           log_response = Net::HTTP.get(URI(log_url))

--- a/lib/fastlane/plugin/notarize/actions/notarize_action.rb
+++ b/lib/fastlane/plugin/notarize/actions/notarize_action.rb
@@ -84,7 +84,7 @@ module Fastlane
         end
 
         log_url = notarization_info['LogFileURL']
-        ENV['NOTARIZE_LOG_FILE_URL'] = log_url
+        ENV['FL_NOTARIZE_LOG_FILE_URL'] = log_url
         log_suffix = ''
         if log_url && print_log
           log_response = Net::HTTP.get(URI(log_url))


### PR DESCRIPTION
Storing the the log file url in an environment variable so it can be used after the notarization. 
Added documentation to inform the user about the existence of this env variable.

Resolves #18 